### PR TITLE
Issue 1: Allow non-root to run program

### DIFF
--- a/gpypi/cli.py
+++ b/gpypi/cli.py
@@ -402,7 +402,8 @@ def main(args=sys.argv[1:]):
     # portage group access must be used for write permission in overlay and for
     # unpacking of ebuilds
     if secpass < 1:
-        main_parser.error('Must be run as root or in group ' + str(portage_gid) )
+        log.warn('Should be run as root or in group ' + str(portage_gid) +
+                ". Expect more problems to come.\n")
 
     config_mgr = ConfigManager.load_from_ini(args.config_file)
     config_mgr.configs['argparse'] = Config.from_argparse(args)

--- a/gpypi/cli.py
+++ b/gpypi/cli.py
@@ -25,6 +25,8 @@ from gpypi.ebuild import Ebuild
 from gpypi.portage_utils import PortageUtils
 from gpypi.utils import PortageFormatter, PortageStreamHandler
 
+# Portages' security level
+from portage.data import secpass, portage_gid
 
 log = logging.getLogger(__name__)
 
@@ -397,10 +399,10 @@ def main(args=sys.argv[1:]):
     else:
         logger.setLevel(logging.INFO)
 
-    # root must be used for write permission in overlay and for
+    # portage group access must be used for write permission in overlay and for
     # unpacking of ebuilds
-    if os.geteuid() != 0:
-        main_parser.error('Must be run as root.')
+    if secpass < 1:
+        main_parser.error('Must be run as root or in group ' + str(portage_gid) )
 
     config_mgr = ConfigManager.load_from_ini(args.config_file)
     config_mgr.configs['argparse'] = Config.from_argparse(args)


### PR DESCRIPTION
Hi iElectric,

I faced exactly isssue https://github.com/iElectric/g-pypi/issues/1. The suggested modifications will allow you to do...

``` bash
gpypi create -l pypi --config-file=$HOME/$CONFIGFILE $PACKAGE
```

...as a normal user. A warning will be issued, when you are not in the group that portage runs in when syncing with the main tree.

Cheers,
Dirk.
